### PR TITLE
include option for --no-require-tls flag

### DIFF
--- a/deployer/dotscience-deployer.yml
+++ b/deployer/dotscience-deployer.yml
@@ -105,7 +105,11 @@ spec:
         - name: deployer
           image: "quay.io/dotmesh/dotscience-deployer:{{ .tag | default "latest" }}"
           imagePullPolicy: Always
+          {{ if .notls }}
+          command: ["ds-deployer", "run", "--no-require-tls"]
+          {{ else }}
           command: ["ds-deployer", "run"]
+          {{ end }}
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
Allows us to pass `?notls=true` on the url so we can launch the deployer without expecting the gateway to have TLS - used for testing